### PR TITLE
Handle root usage with paru

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Run the script directly:
 bash xanadOS_clean.sh
 ```
 
+Run it as a normal user with sudo privileges. Executing the script as root will
+cause AUR helpers like `paru` to fail.
+
 Logs are stored in `~/Documents/system_maint.log` by default.
 
 ## Building an AppImage


### PR DESCRIPTION
## Summary
- prevent running AUR commands as root by adding privilege detection
- install paru using the invoking user when needed
- add `pkg_mgr_run` helper for package operations
- use helper across dependency checks and system updates
- document to run the script as a normal user

## Testing
- `shellcheck xanadOS_clean.sh`
- `bash -n xanadOS_clean.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840119d4d48832fbc9bd40d8391538a