### PR TITLE
Enhance error handling and Arch News features

### DIFF
--- a/AGENTS_SYSTEM.md
+++ b/AGENTS_SYSTEM.md
@@ -80,8 +80,11 @@ monitoring, and cleanup._
   Updates and ranks Arch mirrorlists by speed and protocol. Ensures fast and
   reliable package downloads.
 
-- **`curl`**  
+- **`curl`**
   Used to retrieve and display recent news from the Arch Linux RSS feed.
+
+- **`xmlstarlet`**
+  Parses RSS feeds to display clean Arch news titles.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Arch Linux maintenance. It provides:
 - Security scanning with arch-audit and rkhunter
 - Btrfs maintenance tasks and SSD trimming
 - Checks for failed systemd services and recent journal errors
-- Display of recent Arch news headlines
+- Display of recent Arch news headlines parsed with xmlstarlet
 - System reporting with GPU, firewall, SMART status, and sensors
 - Interactive menu for full or step-by-step maintenance
 


### PR DESCRIPTION
## Summary
- improve error trap to show line and failing command
- require `curl` and `xmlstarlet`
- parse Arch News using `xmlstarlet`
- run flatpak updates non-interactively
- document xmlstarlet in the agents list

## Testing
- `shellcheck xanadOS_clean.sh`
- `bash xanadOS_clean.sh >/tmp/script.log`

------
https://chatgpt.com/codex/tasks/task_e_685296beee3c832f8e11001c03036593