### PR TITLE
Fix cache cleanup to handle hidden files

### DIFF
--- a/xanadOS_clean.sh
+++ b/xanadOS_clean.sh
@@ -259,7 +259,10 @@ cache_cleanup() {
   fi
   read -rp $'\nClean ~/.cache directory? [y/N] ' clean_home
   if [[ ${clean_home,,} =~ ^y ]]; then
-    rm -rf ~/.cache/*
+    # Remove all files, including dotfiles, while preventing globbing issues
+    shopt -s dotglob
+    rm -rf -- ~/.cache/*
+    shopt -u dotglob
     summary "Home cache cleaned."
   fi
   ${SUDO} journalctl --vacuum-time=7d


### PR DESCRIPTION
## Summary
- allow removal of dotfiles in ~/.cache
- use `rm -rf --` to prevent accidental glob expansion

## Testing
- `shellcheck xanadOS_clean.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852990fe74c832fbbd298b8da3c95df