### PR TITLE
Improve Btrfs maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Arch Linux maintenance. It provides:
   installed, with optional Flatpak updates
 - Orphan package removal and cache cleanup with journal rotation
 - Security scanning with arch-audit and rkhunter
-- Btrfs maintenance tasks and SSD trimming
+- Btrfs maintenance tasks with usage-aware balancing and SSD trimming
 - Checks for failed systemd services and recent journal errors
 - Display of recent Arch news headlines parsed with xmlstarlet
 - System reporting with GPU, firewall, SMART status, and sensors


### PR DESCRIPTION
## Summary
- add conditional logic around Btrfs balancing
- scope `RSYNC_DIR` variable inside `rsync_backup`
- mention usage-aware balancing in README

## Testing
- `shellcheck xanadOS_clean.sh`

------
https://chatgpt.com/codex/tasks/task_e_685299c34c58832fa069f42c474ea6fe