### PR TITLE
Add automation flag and network check

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Arch Linux maintenance. It provides:
 - Display of recent Arch news headlines parsed with xmlstarlet
 - System reporting with GPU, firewall, SMART status, and sensors
 - Interactive menu for full or step-by-step maintenance
+- `--auto` flag for unattended execution
 
 ## Usage
 
@@ -24,6 +25,12 @@ Run the script directly:
 
 ```bash
 bash xanadOS_clean.sh
+```
+
+For unattended runs, use the `--auto` flag:
+
+```bash
+bash xanadOS_clean.sh --auto
 ```
 
 Run it as a normal user with sudo privileges. Executing the script as root will


### PR DESCRIPTION
## Summary
- allow unattended operation with `--auto` flag
- skip prompts when in auto mode
- check network connectivity before refreshing mirrors or fetching Arch news
- document auto mode in README

## Testing
- `shellcheck xanadOS_clean.sh`

------
https://chatgpt.com/codex/tasks/task_e_68529b7685e8832f80d6ea4e93a9d39f