### PR TITLE
Fix markdownlint style issues

### DIFF
--- a/AGENTS_CI.md
+++ b/AGENTS_CI.md
@@ -1,8 +1,8 @@
 # AGENTS_CI.md
 
 > **Shell Script Linting & Continuous Integration**  
-> _This file documents the use of ShellCheck for linting and GitHub Actions for
-automated validation of `system_maint.sh`._
+> *This file documents the use of ShellCheck for linting and GitHub Actions for
+automated validation of `system_maint.sh`.*
 
 ---
 
@@ -11,8 +11,8 @@ automated validation of `system_maint.sh`._
 - **`shellcheck`**  
   A static analysis tool for shell scripts. It identifies syntax errors,
   stylistic issues, and unsafe practices in POSIX/Bash scripts.
-  _Used to ensure the long-term maintainability and security of
-  `system_maint.sh`._
+  *Used to ensure the long-term maintainability and security of*
+  `system_maint.sh`.
 
 ### Usage
 

--- a/AGENTS_SECURITY.md
+++ b/AGENTS_SECURITY.md
@@ -1,8 +1,8 @@
 # AGENTS_SECURITY.md
 
 > **Security & Backup Agents**  
-> _This file documents the tools used by `system_maint.sh` for vulnerability
-scanning, rootkit detection, firewall auditing, and backup operations._
+> *This file documents the tools used by `system_maint.sh` for vulnerability
+scanning, rootkit detection, firewall auditing, and backup operations.*
 
 ---
 
@@ -11,16 +11,16 @@ scanning, rootkit detection, firewall auditing, and backup operations._
 - **`arch-audit`**  
   A vulnerability scanner that checks installed Arch Linux packages for known
   CVEs (Common Vulnerabilities and Exposures).
-  _Used to flag outdated or insecure software._
+  *Used to flag outdated or insecure software.*
 
 - **`rkhunter`**  
   Rootkit Hunter scans the system for known rootkits, backdoors, and other
   signs of intrusion.
-  _Updates its database and runs a check with log summaries._
+  *Updates its database and runs a check with log summaries.*
 
 - **`ufw`**  
   The Uncomplicated Firewall. Used to check firewall status and rules.  
-  _Only queried if installed._
+  *Only queried if installed.*
 
 ---
 
@@ -29,17 +29,17 @@ scanning, rootkit detection, firewall auditing, and backup operations._
 - **`timeshift`**  
   Creates system snapshots for rollback. Ideal for backing up system states
   before performing risky operations.
-  _Used if installed and available._
+  *Used if installed and available.*
 
 - **`snapper`**  
   Btrfs snapshot manager. An alternative to Timeshift for Btrfs-managed
   systems.
-  _Only used if Timeshift is not available._
+  *Only used if Timeshift is not available.*
 
 - **`rsync`**  
   Performs a full incremental backup of the root filesystem to a specified
   directory.
-  _Optional and manually triggered during script execution._
+  *Optional and manually triggered during script execution.*
 
 ---
 
@@ -47,11 +47,11 @@ scanning, rootkit detection, firewall auditing, and backup operations._
 
 - **`gamemode`**  
   A runtime daemon that optimizes the system for gaming workloads.  
-  _The script checks its status if installed._
+  *The script checks its status if installed.*
 
 - **`nvidia-utils`**  
   Enables `nvidia-smi` for querying NVIDIA GPU status and temperatures.  
-  _Optional; included for systems with NVIDIA GPUs._
+  *Optional; included for systems with NVIDIA GPUs.*
 
 ---
 

--- a/AGENTS_SYSTEM.md
+++ b/AGENTS_SYSTEM.md
@@ -1,9 +1,9 @@
 # AGENTS_SYSTEM.md
 
 > **System Maintenance Agents**  
-> _This file documents the system-level agents used by the `system_maint.sh`
+> *This file documents the system-level agents used by the `system_maint.sh`
 script to manage core functionality such as packages, storage, system
-monitoring, and cleanup._
+monitoring, and cleanup.*
 
 ---
 
@@ -12,12 +12,12 @@ monitoring, and cleanup._
 - **`pacman`**  
   Arch Linux's default package manager. Used to install, upgrade, and remove
   software packages.
-  _Used when `paru` is not installed._
+  *Used when `paru` is not installed.*
 
 - **`paru`**  
   An AUR helper and frontend for `pacman`. Enables seamless access to Arch User
   Repository (AUR) packages.
-  _Preferred if installed. Script prompts to install if missing._
+  *Preferred if installed. Script prompts to install if missing.*
 
 ---
 


### PR DESCRIPTION
## Summary
- enforce asterisk emphasis in docs

## Testing
- `npm ci`
- `npx markdownlint-cli2 '**/*.md' '!node_modules'`


------
https://chatgpt.com/codex/tasks/task_e_6852a177402c832fb9f673869edf5372