### PR TITLE
Fix markdownlint by ignoring node_modules

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,2 @@
+ignores:
+  - node_modules


### PR DESCRIPTION
## Summary
- add `.markdownlint-cli2.yaml` to ignore `node_modules`

## Testing
- `npm ci`
- `npx markdownlint-cli2 '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_6852a177402c832fb9f673869edf5372