### PR TITLE
Replace system_maint references with xanadOS_clean

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
 # AGENTS Repository Guide
 
 This repository provides documentation and examples for the
-`system_maint.sh` script. The instructions below apply to all contributions.
+`xanadOS_clean.sh` script. The instructions below apply to all contributions.
 
-The repository does not contain the `system_maint.sh` script itself;
+The repository does not contain the `xanadOS_clean.sh` script itself;
 use these files as a reference for your own copy.
 
 ## Documentation Layout
@@ -20,7 +20,7 @@ Refer to these files if you need details about dependencies or CI features.
    (e.g. `Add root AGENTS guide`).
 2. **Include a brief body** if the commit needs more context.
 3. **Run relevant checks** before committing:
-   - If `system_maint.sh` exists, execute `shellcheck system_maint.sh`.
+   - If `xanadOS_clean.sh` exists, execute `shellcheck xanadOS_clean.sh`.
 4. **Open a Pull Request** summarising what changed and what checks were run.
 
 ## Pull Request Body

--- a/AGENTS_CI.md
+++ b/AGENTS_CI.md
@@ -2,7 +2,7 @@
 
 > **Shell Script Linting & Continuous Integration**  
 > *This file documents the use of ShellCheck for linting and GitHub Actions for
-automated validation of `system_maint.sh`.*
+automated validation of `xanadOS_clean.sh`.*
 
 ---
 
@@ -12,14 +12,14 @@ automated validation of `system_maint.sh`.*
   A static analysis tool for shell scripts. It identifies syntax errors,
   stylistic issues, and unsafe practices in POSIX/Bash scripts.
   *Used to ensure the long-term maintainability and security of*
-  `system_maint.sh`.
+  `xanadOS_clean.sh`.
 
 ### Usage
 
 To manually check your script:
 
 ```bash
-shellcheck system_maint.sh
+shellcheck xanadOS_clean.sh
 ```
 
 ---

--- a/AGENTS_SECURITY.md
+++ b/AGENTS_SECURITY.md
@@ -1,7 +1,7 @@
 # AGENTS_SECURITY.md
 
 > **Security & Backup Agents**  
-> *This file documents the tools used by `system_maint.sh` for vulnerability
+> *This file documents the tools used by `xanadOS_clean.sh` for vulnerability
 scanning, rootkit detection, firewall auditing, and backup operations.*
 
 ---

--- a/AGENTS_SYSTEM.md
+++ b/AGENTS_SYSTEM.md
@@ -1,7 +1,7 @@
 # AGENTS_SYSTEM.md
 
-> **System Maintenance Agents**  
-> *This file documents the system-level agents used by the `system_maint.sh`
+> **System Maintenance Agents**
+> *This file documents the system-level agents used by the `xanadOS_clean.sh`
 script to manage core functionality such as packages, storage, system
 monitoring, and cleanup.*
 
@@ -91,7 +91,7 @@ monitoring, and cleanup.*
 ## Notes
 
 - These agents are considered **essential** for the baseline operation of
-  `system_maint.sh`.
+  `xanadOS_clean.sh`.
 - The script attempts to detect and use each tool. If a tool is missing and
   required, it will prompt for installation or skip the related functionality.
 


### PR DESCRIPTION
## Summary
- update AGENTS docs to reference `xanadOS_clean.sh` instead of `system_maint.sh`

## Testing
- `shellcheck xanadOS_clean.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852c3928afc832fb15bcbcd1affcf0c