### PR TITLE
Fix progress counter error

### DIFF
--- a/xanadOS_clean.sh
+++ b/xanadOS_clean.sh
@@ -47,7 +47,7 @@ CURRENT_STEP=0
 
 show_progress() {
   local desc=$1
-  ((CURRENT_STEP++))
+  ((++CURRENT_STEP))
   local width=30
   local filled=$((CURRENT_STEP * width / TOTAL_STEPS))
   local empty=$((width - filled))


### PR DESCRIPTION
## Summary
- prevent show_progress from exiting the script

## Testing
- `shellcheck xanadOS_clean.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852c6e7a9c8832f880c064469a54965