### PR TITLE
Add pacman requirement check

### DIFF
--- a/xanadOS_clean.sh
+++ b/xanadOS_clean.sh
@@ -116,6 +116,13 @@ check_network() {
   ping -c1 -W2 archlinux.org >/dev/null 2>&1
 }
 
+require_pacman() {
+  if ! command -v pacman >/dev/null 2>&1; then
+    error "pacman is required. This script only runs on Arch Linux."
+    exit 1
+  fi
+}
+
 refresh_mirrors() {
   print_banner "Refresh Mirrors"
   if ! check_network; then
@@ -473,6 +480,7 @@ main_menu() {
 }
 
 main() {
+  require_pacman
   print_banner "Arch Maintenance"
   if [[ ${AUTO_MODE} != true ]]; then
     main_menu


### PR DESCRIPTION
## Summary
- stop execution if `pacman` isn't installed

## Testing
- `shellcheck xanadOS_clean.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852c8725164832fa92e26cb5d2d5203