### PR TITLE
Update docs for arch and bazzite support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
 # AGENTS Repository Guide
 
 This repository provides documentation and examples for the
-`xanadOS_clean.sh` script. The instructions below apply to all contributions.
+system maintenance scripts `archlinux_clean.sh` and `bazzite_clean.sh`.
+The instructions below apply to all contributions.
 
-The repository does not contain the `xanadOS_clean.sh` script itself;
-use these files as a reference for your own copy.
+The repository does not contain a unified `xanadOS_clean.sh` script;
+use these files as references for your own copies.
 
 ## Documentation Layout
 
@@ -20,7 +21,8 @@ Refer to these files if you need details about dependencies or CI features.
    (e.g. `Add root AGENTS guide`).
 2. **Include a brief body** if the commit needs more context.
 3. **Run relevant checks** before committing:
-   - If `xanadOS_clean.sh` exists, execute `shellcheck xanadOS_clean.sh`.
+   - If `archlinux_clean.sh` or `bazzite_clean.sh` exist, run `shellcheck` on
+     them.
 4. **Open a Pull Request** summarising what changed and what checks were run.
 
 ## Pull Request Body

--- a/AGENTS_CI.md
+++ b/AGENTS_CI.md
@@ -1,8 +1,8 @@
 # AGENTS_CI.md
 
-> **Shell Script Linting & Continuous Integration**  
+> **Shell Script Linting & Continuous Integration**
 > *This file documents the use of ShellCheck for linting and GitHub Actions for
-automated validation of `xanadOS_clean.sh`.*
+automated validation of the maintenance scripts.*
 
 ---
 
@@ -11,15 +11,16 @@ automated validation of `xanadOS_clean.sh`.*
 - **`shellcheck`**  
   A static analysis tool for shell scripts. It identifies syntax errors,
   stylistic issues, and unsafe practices in POSIX/Bash scripts.
-  *Used to ensure the long-term maintainability and security of*
-  `xanadOS_clean.sh`.
+  *Used to ensure the long-term maintainability and security of the
+  maintenance scripts.*
 
 ### Usage
 
 To manually check your script:
 
 ```bash
-shellcheck xanadOS_clean.sh
+shellcheck archlinux_clean.sh
+shellcheck bazzite_clean.sh
 ```
 
 ---

--- a/AGENTS_SECURITY.md
+++ b/AGENTS_SECURITY.md
@@ -1,17 +1,18 @@
 # AGENTS_SECURITY.md
 
-> **Security & Backup Agents**  
-> *This file documents the tools used by `xanadOS_clean.sh` for vulnerability
-scanning, rootkit detection, firewall auditing, and backup operations.*
+> **Security & Backup Agents**
+> *This file documents the tools used by the maintenance scripts for
+vulnerability scanning, rootkit detection, firewall auditing, and backup
+operations.*
 
 ---
 
 ## 🛡️ Security & Auditing Tools
 
-- **`arch-audit`**  
+- **`arch-audit`** (Arch only)
   A vulnerability scanner that checks installed Arch Linux packages for known
   CVEs (Common Vulnerabilities and Exposures).
-  *Used to flag outdated or insecure software.*
+  *Used to flag outdated or insecure software when running the Arch variant.*
 
 - **`rkhunter`**  
   Rootkit Hunter scans the system for known rootkits, backdoors, and other

--- a/AGENTS_SYSTEM.md
+++ b/AGENTS_SYSTEM.md
@@ -1,9 +1,9 @@
 # AGENTS_SYSTEM.md
 
 > **System Maintenance Agents**
-> *This file documents the system-level agents used by the `xanadOS_clean.sh`
-script to manage core functionality such as packages, storage, system
-monitoring, and cleanup.*
+> *This file documents the system-level agents used by the maintenance scripts
+to manage core functionality such as packages, storage, system monitoring,
+and cleanup.*
 
 ---
 
@@ -14,10 +14,18 @@ monitoring, and cleanup.*
   software packages.
   *Used when `paru` is not installed.*
 
-- **`paru`**  
+- **`paru`**
   An AUR helper and frontend for `pacman`. Enables seamless access to Arch User
   Repository (AUR) packages.
   *Preferred if installed. Script prompts to install if missing.*
+
+- **`dnf`**
+  Fedora's package manager used on Bazzite for installing and upgrading
+  packages when not using rpm-ostree.
+
+- **`rpm-ostree`**
+  Manages immutable Fedora-based systems such as Bazzite. Used to apply
+  atomic upgrades when available.
 
 ---
 
@@ -60,9 +68,13 @@ monitoring, and cleanup.*
 
 ## 🧹 System Cleanup
 
-- **`paccache`**  
+- **`paccache`**
   Part of the `pacman-contrib` package. Used to clean outdated package versions
   from the local cache.
+
+- **`dnf autoremove`**
+  Removes unneeded packages on Fedora/Bazzite systems. The script also runs
+  `dnf clean` to clear metadata.
 
 - **`journalctl`**  
   Systemd log viewer. Used to rotate logs older than 7 days and display
@@ -76,22 +88,26 @@ monitoring, and cleanup.*
 
 ## 📡 Network Operations
 
-- **`reflector`**  
+- **`reflector`**
   Updates and ranks Arch mirrorlists by speed and protocol. Ensures fast and
   reliable package downloads.
 
+- **`dnf-plugins-core`**
+  Provides `fastestmirror` for optimizing Fedora mirror selection.
+
 - **`curl`**
-  Used to retrieve and display recent news from the Arch Linux RSS feed.
+  Used to retrieve and display recent news from distribution RSS feeds
+  (Arch Linux or Fedora).
 
 - **`xmlstarlet`**
-  Parses RSS feeds to display clean Arch news titles.
+  Parses RSS feeds to display clean news titles.
 
 ---
 
 ## Notes
 
 - These agents are considered **essential** for the baseline operation of
-  `xanadOS_clean.sh`.
+  the maintenance scripts.
 - The script attempts to detect and use each tool. If a tool is missing and
   required, it will prompt for installation or skip the related functionality.
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,49 @@
 # xanadOS Clean
 
-This repository contains `xanadOS_clean.sh`, a comprehensive Bash script for
-Arch Linux maintenance. It provides:
+This repository contains example maintenance scripts for Linux systems.
+Two versions are included to suit different distributions:
 
-- Mirror refresh using Reflector
-- Prompted installation of the `paru` AUR helper or fallback to pacman
-- Optional system backups via Timeshift, Snapper, or user-defined `rsync` \
+- **`archlinux_clean.sh`** – for Arch-based systems
+- **`bazzite_clean.sh`** – for Fedora/Bazzite systems
+
+Both scripts provide:
+
+- Package updates using `pacman/paru` or `dnf/rpm-ostree` depending on the
+  distribution
+- Mirror or repository refresh prior to upgrades
+- Optional system backups via Timeshift, Snapper, or user-defined `rsync`
   (skipped if a snapshot exists from the last 30 days)
 - Dependency checking with interactive installation of recommended packages
-- System updates using `paru -Syu` or `sudo pacman -Syu` if paru isn't
-  installed, with optional Flatpak updates
+- Optional Flatpak updates
 - Orphan package removal and cache cleanup with journal rotation
-- Security scanning with arch-audit and rkhunter
+- Security scanning with rkhunter (plus `arch-audit` on Arch)
 - Btrfs maintenance tasks with usage-aware balancing and SSD trimming
 - Checks for failed systemd services and recent journal errors
-- Display of recent Arch news headlines parsed with xmlstarlet
+- Display of distribution news headlines (Arch or Fedora) parsed with xmlstarlet
 - System reporting with GPU, firewall, SMART status, and sensors
 - Interactive menu for full or step-by-step maintenance
 - `--auto` flag for unattended execution
 
 ## Usage
 
-Run the script directly:
+Run the script for your distribution. Examples:
 
 ```bash
-bash xanadOS_clean.sh
+# For Arch-based systems
+bash archlinux_clean.sh
+
+# For Fedora/Bazzite
+bash bazzite_clean.sh
 ```
 
 For unattended runs, use the `--auto` flag:
 
 ```bash
-bash xanadOS_clean.sh --auto
+bash archlinux_clean.sh --auto
+
+# or
+
+bash bazzite_clean.sh --auto
 ```
 
 Run it as a normal user with sudo privileges. Executing the script as root will
@@ -40,13 +53,13 @@ Logs are stored in `~/Documents/system_maint.log` by default.
 
 ## Building an AppImage
 
-An example `build_appimage.sh` script is included to package the maintenance
-script as an AppImage. The steps are:
+An example `build_appimage.sh` script is included to package one of the
+maintenance scripts as an AppImage. The steps are:
 
 1. Execute the build script:
 
 ```bash
-bash build_appimage.sh
+bash build_appimage.sh archlinux_clean.sh
 ```
 
 1. The resulting `xanadOS_clean-1.0.AppImage` can then be distributed and run

--- a/build_appimage.sh
+++ b/build_appimage.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 APP=xanadOS_clean
 VERSION=1.0
 APPDIR="${APP}.AppDir"
+SCRIPT=${1:-archlinux_clean.sh}
 APPIMAGETOOL_URL="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
 APPIMAGETOOL_SHA256="b90f4a8b18967545fda78a445b27680a1642f1ef9488ced28b65398f2be7add2"
 
@@ -22,7 +23,7 @@ download_appimagetool() {
 
 rm -rf "$APPDIR"
 mkdir -p "$APPDIR/usr/bin"
-cp xanadOS_clean.sh "$APPDIR/usr/bin/$APP"
+cp "$SCRIPT" "$APPDIR/usr/bin/$APP"
 chmod +x "$APPDIR/usr/bin/$APP"
 
 cat > "$APPDIR/$APP.desktop" <<DESK

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xanados_clean",
   "version": "1.0.0",
-  "description": "This repository contains `xanadOS_clean.sh`, a comprehensive Bash script for Arch Linux maintenance. It provides:",
+  "description": "Example maintenance scripts for Arch and Fedora/Bazzite systems.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Summary
- document new `archlinux_clean.sh` and `bazzite_clean.sh` scripts
- generalize AGENTS docs away from `xanadOS_clean.sh`
- add Fedora tooling to system agents docs
- make build_appimage.sh accept a script argument
- update package metadata

## Testing
- `shellcheck archlinux_clean.sh`
- `shellcheck bazzite_clean.sh`


------
https://chatgpt.com/codex/tasks/task_e_686673fa31f4832f8f575653ae88063f